### PR TITLE
Fix Quick Reference display issue

### DIFF
--- a/activegate_troubleshooting_new.html
+++ b/activegate_troubleshooting_new.html
@@ -303,6 +303,11 @@
         .status-warning { background: #feca57; }
         .status-up { background: #48dbfb; }
 
+        code {
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+
         @media (max-width: 768px) {
             .header h1 {
                 font-size: 2rem;


### PR DESCRIPTION
## Summary
- allow long code text to wrap so log paths don't overlap other text

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849e46e7b6c83238b948c5096225702