### PR TITLE
Fix quick reference log path formatting

### DIFF
--- a/activegate_troubleshooting_new.html
+++ b/activegate_troubleshooting_new.html
@@ -305,7 +305,8 @@
 
         code {
             white-space: pre-wrap;
-            word-break: break-all;
+            word-break: break-word;
+            overflow-wrap: anywhere;
         }
 
         @media (max-width: 768px) {
@@ -345,7 +346,7 @@
                         <h4 style="color: #4ecdc4; margin-bottom: 10px;">🗂️ Log Locations</h4>
                         <div style="font-size: 0.9rem; line-height: 1.5;">
                             <strong>Linux:</strong><br>
-                            <code>/var/log/dynatrace/gateway/dynatracegateway*.log</code><br><br>
+                            <code>/var/log/dynatrace/gateway/<wbr>dynatracegateway*.log</code><br><br>
                             <strong>Windows:</strong><br>
                             <code>%PROGRAMDATA%\dynatrace\gateway\log\</code><br><br>
                             <strong>Installer logs:</strong> Look for *install.log files


### PR DESCRIPTION
## Summary
- fix overlapping log path by inserting a word break
- allow code snippets to wrap anywhere for better layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f1dd41e48323a10f819cea31f89b